### PR TITLE
make sure parsed secret type is the correct value type

### DIFF
--- a/tests/local_bongo_rest_parser_test.php
+++ b/tests/local_bongo_rest_parser_test.php
@@ -71,7 +71,7 @@ class local_bongo_rest_parser_testcase extends basic_testcase {
 
         assert($parsedresponse->url == $url, 'Rest URL was not parsed correctly!' . var_dump($parsedresponse));
         assert($parsedresponse->key == $key, 'Rest Key was not parsed correctly!' . var_dump($parsedresponse));
-        assert($parsedresponse->secret == $secret, 'Rest secret was not parsed correctly!' . var_dump($parsedresponse));
+        assert($parsedresponse->secret === $secret, 'Rest secret was not parsed correctly!' . var_dump($parsedresponse));
         assert($parsedresponse->region == $region, 'Rest region was not parsed correctly!' . var_dump($parsedresponse));
 
     }


### PR DESCRIPTION
Minor fix to check the type of the parsed secret in the test code. Shouldn't affect the functionality of the plugin but just to be safe.